### PR TITLE
Add an experiment with dynamic limit changing

### DIFF
--- a/simulation/experiments/limit_changing/dispatcher.py
+++ b/simulation/experiments/limit_changing/dispatcher.py
@@ -1,0 +1,49 @@
+from interfaces import AbstractDispatcher
+from jobs import JobDurationIndex
+from workers import WorkerQueue
+
+
+def duration_filter(est_duration):
+    def fnc(w):
+        limit = w.get_attribute("limit")
+        return limit is None or limit >= est_duration
+    return fnc
+
+class LimitChangingJobCategoryDispatcher(AbstractDispatcher):
+    """Dispatcher that tries to improve user experience by placing long jobs in a separate queue.
+
+    The estimation whether a job will be short or long is based on jobs that were already evaluated
+    (both regular and ref.). The SA strategy is responsible for filling data for the estimator.
+    """
+
+    def __init__(self):
+        # the dispatching algorithm only reads the index, SA strategy is responsible for filling the data
+        self.duration_index = JobDurationIndex()
+
+    def init(self, ts, workers):
+        pass
+
+    def dispatch(self, job, workers):
+        # we need to estimate the duration of the job first (! no peeking to job.duration !)
+        estimate = self.duration_index.estimate_duration(job.exercise_id, job.runtime_id)
+        if estimate is None:
+            estimate = job.limits / 2.0
+
+        # get all workers marked as active
+        active_workers = list(filter(lambda w: w.get_attribute("active"), workers))
+        if not active_workers:
+            raise RuntimeError("No active workers available, unable to dispatch job.")
+
+        # select workers where the job would fit (estimate duration is under worker limit)
+        best_workers = list(filter(duration_filter(estimate), active_workers))
+        if len(best_workers) == 0:
+            best_workers = active_workers  # fallback, if no worker passes the limit
+
+        best_workers.sort(key=lambda w: w.jobs_count())
+        target = best_workers[0]
+        target.enqueue(job)
+
+    def add_ref_job(self, job):
+        """External interface for SA strategy (which can add jobs to index to modify dispatcher behavior)."""
+        self.duration_index.add(job)
+

--- a/simulation/experiments/limit_changing/sa_strategy.py
+++ b/simulation/experiments/limit_changing/sa_strategy.py
@@ -1,0 +1,77 @@
+from interfaces import AbstractSelfAdaptingStrategy
+from logger import logWorkers, sampleLog
+
+def decrease_worker_limit(adaptive_worker):
+        if adaptive_worker.get_attribute("limit")-adaptive_worker.get_attribute("agression") < adaptive_worker.get_attribute("limit-min"):
+            adaptive_worker.set_attribute("limit", adaptive_worker.get_attribute("limit-min"))
+        else:
+            adaptive_worker.set_attribute("limit", adaptive_worker.get_attribute("limit")-(adaptive_worker.get_attribute("agression")*.75))
+    
+def increase_worker_limit(worker):
+    worker.set_attribute("limit", worker.get_attribute("limit")+worker.get_attribute("agression"))
+
+
+
+class LimitChangingCategorySelfAdaptingStrategy(AbstractSelfAdaptingStrategy):
+    """Represents a SA controller that uses simple machine learning.
+
+    Collects job and ref. job metadata to compute categorized statistics of job duration based on their
+    affiliation to exercises and runtimes. These statistics are used by dispatcher for predicting the duration
+    of incomming jobs.
+
+    If there is a larger queue with at least three items in it and this queue is empty increase
+    the limit by x seconds
+
+    If there is an empty larger queue decrease the limit by x seconds
+    """
+
+    def __init__(self, max_long_queues, ref_jobs):
+        self.max_long_queues = max_long_queues
+        self.ref_jobs = ref_jobs[:]
+        self.ref_jobs.reverse()
+
+    def _update_dispatcher(self, ts, dispatcher):
+        while len(self.ref_jobs) > 0 and self.ref_jobs[-1].spawn_ts + self.ref_jobs[-1].duration <= ts:
+            job = self.ref_jobs.pop()
+            if job.compilation_ok:
+                dispatcher.add_ref_job(job)
+
+    def init(self, ts, dispatcher, workers):
+        self._update_dispatcher(ts, dispatcher)
+
+    def do_adapt(self, ts, dispatcher, workers, job=None):
+        self._update_dispatcher(ts, dispatcher)
+
+        workers.sort(key=lambda w: w.get_attribute("limit") == None, reverse=True )
+        adaptive_limits = []
+        overloaded = []
+        empty = []
+
+        for i in range(len(workers)):
+            worker = workers[i]
+            if worker.get_attribute("adaptive-limit"):
+                adaptive_limits.append(worker)
+            if worker.jobs_count() > 1:
+                overloaded.append(worker)
+            if worker.jobs_count() == 0:
+                empty.append(worker)
+
+        higherLimitLambda = lambda w: w.get_attribute("limit") is None or w.get_attribute("limit") > adaptive_worker.get_attribute("limit")
+        
+        for adaptive_worker in adaptive_limits:
+            higherLimitsOverloaded = tuple(filter(higherLimitLambda, overloaded))
+            higherLimitsEmpty = tuple(filter(higherLimitLambda, empty))
+            if len(higherLimitsOverloaded) > 0:
+                increase_worker_limit(adaptive_worker)
+                logWorkers(workers)
+            elif len(higherLimitsEmpty) > 0 and adaptive_worker.get_attribute("limit") > adaptive_worker.get_attribute("limit-min"):
+                decrease_worker_limit(adaptive_worker)
+                logWorkers(workers)
+
+        sampleLog(workers)
+            
+
+        if (job and job.compilation_ok):
+            dispatcher.add_ref_job(job)
+
+    

--- a/simulation/experiments/limit_changing/sa_strategy.py
+++ b/simulation/experiments/limit_changing/sa_strategy.py
@@ -49,7 +49,7 @@ class LimitChangingCategorySelfAdaptingStrategy(AbstractSelfAdaptingStrategy):
 
         for i in range(len(workers)):
             worker = workers[i]
-            if worker.get_attribute("adaptive-limit"):
+            if worker.get_attribute("dynamic-limit"):
                 adaptive_limits.append(worker)
             if worker.jobs_count() > 1:
                 overloaded.append(worker)

--- a/simulation/experiments/limit_changing/sa_strategy.py
+++ b/simulation/experiments/limit_changing/sa_strategy.py
@@ -2,13 +2,13 @@ from interfaces import AbstractSelfAdaptingStrategy
 from logger import logWorkers, sampleLog
 
 def decrease_worker_limit(adaptive_worker):
-        if adaptive_worker.get_attribute("limit")-adaptive_worker.get_attribute("agression") < adaptive_worker.get_attribute("limit-min"):
+        if adaptive_worker.get_attribute("limit")-adaptive_worker.get_attribute("aggression") < adaptive_worker.get_attribute("limit-min"):
             adaptive_worker.set_attribute("limit", adaptive_worker.get_attribute("limit-min"))
         else:
-            adaptive_worker.set_attribute("limit", adaptive_worker.get_attribute("limit")-(adaptive_worker.get_attribute("agression")*.75))
+            adaptive_worker.set_attribute("limit", adaptive_worker.get_attribute("limit")-(adaptive_worker.get_attribute("aggression")*.75))
     
 def increase_worker_limit(worker):
-    worker.set_attribute("limit", worker.get_attribute("limit")+worker.get_attribute("agression"))
+    worker.set_attribute("limit", worker.get_attribute("limit")+worker.get_attribute("aggression"))
 
 
 

--- a/simulation/experiments/user_experience_adaptive_limits.yaml
+++ b/simulation/experiments/user_experience_adaptive_limits.yaml
@@ -1,0 +1,47 @@
+# Scenario where user experience based on job latency is the top criterium.
+# Short jobs needs to be evaluated almost interactively, long jobs may be delayed much longer.
+# The objective is achieved by imposing limits on queues, only jobs that are expected to
+# take no more than given limit are allowed in (all queues remain active the whole time).
+# The key part of the scenario is the duration estimation algorithm used by dispatcher.
+
+# This configuration uses job dispatcher and SA strategy that estimates job duration
+# based on previous jobs (including ref. jobs). The SA fills an index (estimation structure),
+# dispatcher uses the duration index to make the estimates.
+
+
+# Workers could be either a number or a list that explicitly states a collection of attributes
+# If only a number is given, the workers are initialized with no attributes at the beginning.
+workers:
+  - active: true
+  - active: true
+    limit-min: 30.0
+    limit: 30.0
+    agression: 10.0
+    adaptive-limit: true
+  - active: true
+    limit-min: 30.0
+    limit: 30.0
+    agression: 10.0
+    adaptive-limit: true
+  - active: true
+    limit: 30.0
+
+# dispatcher component: either a string (fully qualified class name) or a collection with { class, args }
+# where class is fully qualified class name and args is list or dict holding constructor arguments
+dispatcher: experiments.limit_changing.dispatcher.LimitChangingJobCategoryDispatcher
+
+# self-adapting strategy component (same format as dispatcher)
+sa_strategy:
+  class: experiments.limit_changing.sa_strategy.LimitChangingCategorySelfAdaptingStrategy
+  args:
+    - 2  # max. number of long worker queues
+    - "@@ref_jobs"
+period: 60  # in seconds, how often a sa strategy (MAPE-K loop) is invoked
+
+# list of metric components (each one is in the same format as dispatcher)
+metrics:
+  - metrics.default.JobDelayMetricsCollector
+  - class: metrics.user_experience.UserExperienceMetricsCollector
+    args:
+      - "@@ref_jobs"
+      - [ 1.5, 3.0 ]  # thresholds

--- a/simulation/experiments/user_experience_adaptive_limits.yaml
+++ b/simulation/experiments/user_experience_adaptive_limits.yaml
@@ -17,12 +17,12 @@ workers:
     limit-min: 30.0
     limit: 30.0
     agression: 10.0
-    adaptive-limit: true
+    dynamic-limit: true
   - active: true
     limit-min: 30.0
     limit: 30.0
     agression: 10.0
-    adaptive-limit: true
+    dynamic-limit: true
   - active: true
     limit: 30.0
 

--- a/simulation/experiments/user_experience_adaptive_limits.yaml
+++ b/simulation/experiments/user_experience_adaptive_limits.yaml
@@ -16,12 +16,12 @@ workers:
   - active: true
     limit-min: 30.0
     limit: 30.0
-    agression: 10.0
+    aggression: 10.0
     dynamic-limit: true
   - active: true
     limit-min: 30.0
     limit: 30.0
-    agression: 10.0
+    aggression: 10.0
     dynamic-limit: true
   - active: true
     limit: 30.0

--- a/simulation/logger.py
+++ b/simulation/logger.py
@@ -1,0 +1,20 @@
+
+DEBUG = False
+INDEX = 0
+def log(logline, end="\n"):
+    if DEBUG:
+        print(logline,end=end)
+
+def logWorker(worker):
+    log(f"Worker:{worker.attributes}", end=" -- ")
+
+def logWorkers(workers):
+    for worker in workers:
+        logWorker(worker)
+    log("")
+
+def sampleLog(workers):
+    global INDEX
+    if INDEX % 10000 == 0:
+        logWorkers(workers)
+    INDEX+=1

--- a/simulation/main.py
+++ b/simulation/main.py
@@ -10,7 +10,8 @@ from simulation import Simulation
 def get_configuration(config_file):
     with open(config_file, "r") as stream:
         try:
-            return yaml.safe_load(stream)
+            yamlreader = yaml.YAML(typ='safe', pure=True)
+            return yamlreader.load(stream)
         except yaml.YAMLError as e:
             print("Simulation config file {} is not in YAML format.".format(config_file))
             print(e)


### PR DESCRIPTION
This PR adds another experiment that allows limited queues to change their size based on a backlog of jobs in a queue with a higher limit. As well as that there is a small update that fixes a deprecated yaml safe-read method in main

### Changes to YAML configuration file
For dynamic limit workers there are 3 new required attributes:

-    `dynamic-limit: bool` (to indicate if the worker should be dynamic)
-    `min-limit: float` (to set the minimum size of the worker)
-    `aggression:float` (to set how much the worker should increase or decrease its size based on other worker queues)

For dynamic limit workers the previous `limit` attribute now determines the default starting size. 

### Results
An experiment with 1 unlimited queue, 1 30-second static queue and 2 dynamic queues performs better than the original user experience experiment with 1 unlimited queue and 3 30-second static limit queues, decreasing the average delay, max delay, and number of late jobs significantly.

User Experience static queues results:
Total jobs: 398302, avg. delay: **62.089308951997175**, max. delay: **34752.292999982834**
Total jobs: 398302, on time: 387502, delayed: 1928, late: **8872**

Dynamic Queues results:
Total jobs: 398302, avg. delay: **13.047628269740942**, max. delay: **18335.957000494003**
Total jobs: 398302, on time: 391450, delayed: 1589, late: **5263**

